### PR TITLE
Added catkin to packages to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you have an available ROS Noetic system, you can quickly install and run Proj
     cd project11/catkin_ws/src
     git clone https://github.com/CCOMJHC/project11.git
 
-    sudo apt-get install python3-rosdep python3-vcstool
+    sudo apt-get install python3-rosdep python3-vcstool catkin
     rosdep update
 
     vcs import < project11/config/repos/sim_demo.repos


### PR DESCRIPTION
Catkin is not installed during the standard ROS installs and must be installed separately. It is added here.