### PR TITLE
added ben_description back to sim_demo.repos

### DIFF
--- a/config/repos/sim_demo.repos
+++ b/config/repos/sim_demo.repos
@@ -88,7 +88,7 @@ repositories:
     url: https://github.com/CCOMJHC/remote_manager.git
   robots/ben_description:
     type: git
-    url: https://github.com/rolker/ben_description.git
+    url: https://github.com/CCOMJHC/ben_description.git
     version: noetic
   traffic_sim:
     type: git

--- a/config/repos/sim_demo.repos
+++ b/config/repos/sim_demo.repos
@@ -86,6 +86,9 @@ repositories:
   remote_manager:
     type: git
     url: https://github.com/CCOMJHC/remote_manager.git
+  robots/ben_description:
+    type: git
+    url: https://github.com/rolker/ben_description.git
     version: noetic
   traffic_sim:
     type: git

--- a/config/repos/sim_demo.repos
+++ b/config/repos/sim_demo.repos
@@ -86,7 +86,7 @@ repositories:
   remote_manager:
     type: git
     url: https://github.com/CCOMJHC/remote_manager.git
-  robots/ben_description:
+  ben_description:
     type: git
     url: https://github.com/CCOMJHC/ben_description.git
     version: noetic


### PR DESCRIPTION
Added the ben_description reference back to sim_demo.repos and confirmed that it solves the Resource not found error when following the demo setup guide